### PR TITLE
add artifacts import(in json format)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 .buildlog/
 .history
 .svn/
+.vscode/
+node_modules/
 
 # IntelliJ related
 *.iml

--- a/packages/genshindb/lib/src/good/good.dart
+++ b/packages/genshindb/lib/src/good/good.dart
@@ -131,6 +131,12 @@ class GOOD with _$GOOD {
     );
   }
 
+  GOOD importArtifacts(List<GOODArtifact> artifacts) {
+    return copyWith(
+      artifacts: artifacts,
+    );
+  }
+
   GOOD equipArtifact(GOODArtifact artifact, GOODArtifact? from) {
     if (from != null) {
       if (from.location == artifact.location) {

--- a/packages/genshindb/lib/src/services/character_service.dart
+++ b/packages/genshindb/lib/src/services/character_service.dart
@@ -44,6 +44,20 @@ class CharacterService with _$CharacterService {
     return characters?[_indexes[keyOrName]];
   }
 
+  String? getCharacterKey(String? keyOrName) {
+    if (keyOrName == null) return null;
+    if (_indexes.isEmpty) {
+      characters?.forEach((key, value) {
+        _indexes["${value.id}"] = value.key;
+        for (var lang in value.name.keys) {
+          _indexes[value.name.text(lang)] = value.key;
+        }
+      });
+    }
+
+    return _indexes[keyOrName];
+  }
+
   FightProps fightProps(
     String keyOrName,
     int level,

--- a/packages/genshintoolsapp/android/app/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java
+++ b/packages/genshintoolsapp/android/app/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java
@@ -16,6 +16,16 @@ public final class GeneratedPluginRegistrant {
   private static final String TAG = "GeneratedPluginRegistrant";
   public static void registerWith(@NonNull FlutterEngine flutterEngine) {
     try {
+      flutterEngine.getPlugins().add(new com.mr.flutter.plugin.filepicker.FilePickerPlugin());
+    } catch(Exception e) {
+      Log.e(TAG, "Error registering plugin file_picker, com.mr.flutter.plugin.filepicker.FilePickerPlugin", e);
+    }
+    try {
+      flutterEngine.getPlugins().add(new io.flutter.plugins.flutter_plugin_android_lifecycle.FlutterAndroidLifecyclePlugin());
+    } catch(Exception e) {
+      Log.e(TAG, "Error registering plugin flutter_plugin_android_lifecycle, io.flutter.plugins.flutter_plugin_android_lifecycle.FlutterAndroidLifecyclePlugin", e);
+    }
+    try {
       flutterEngine.getPlugins().add(new dev.fluttercommunity.plus.packageinfo.PackageInfoPlugin());
     } catch(Exception e) {
       Log.e(TAG, "Error registering plugin package_info_plus, dev.fluttercommunity.plus.packageinfo.PackageInfoPlugin", e);

--- a/packages/genshintoolsapp/lib/domain/gamedata/bloc_game_data.dart
+++ b/packages/genshintoolsapp/lib/domain/gamedata/bloc_game_data.dart
@@ -143,6 +143,10 @@ class BlocGameData extends HydratedCubit<PlayerStates> with WebDAVSyncMixin {
     }
   }
 
+  void importArtifacts(int uid, List<GOODArtifact> artifacts) {
+    emit({...state, uid: playerState(uid).importArtifacts(artifacts)});
+  }
+
   void equipArtifact(int uid, GOODArtifact artifact, [GOODArtifact? value]) {
     emit({...state, uid: playerState(uid).equipArtifact(artifact, value)});
   }

--- a/packages/genshintoolsapp/pubspec.yaml
+++ b/packages/genshintoolsapp/pubspec.yaml
@@ -25,6 +25,7 @@ dependencies:
   webview_flutter: ^3.0.0
   flutter_hooks: ^0.18.1
   rxdart: ^0.27.3
+  file_picker: ^4.3.3
 
   genshingameinfo:
     path: "../genshingameinfo"


### PR DESCRIPTION
Add:
- 圣遗物界面新增按钮处长按可以弹出批量导入窗口，使用[file_picker](https://pub.dev/packages/file_picker)实现
- 支持多种扫描工具导出的圣遗物json格式，包括`GOOD`(可用[Amenoma](https://github.com/daydreaming666/Amenoma)扫描导出)、`mona-uranai`(可用[Amenoma](https://github.com/daydreaming666/Amenoma)、[YAS](https://github.com/wormtql/yas)扫描导出)


Todo:
- 格式转换较粗糙缺少异常检测待优化
- 目前扫描工具均不支持导出圣遗物装备角色(YAS可以识别但导出json中不包含，可使用简单修改后的[YAS](https://github.com/Escheee/yas)，更优雅的方式是在YAS中用rust实现直接导出为GOOD格式)
- 导出包含装备角色的圣遗物列表可以直接用来更新角色界面的已装备圣遗物并计算得分，但由于[`useObservableEffect`](https://github.com/morlay/genshintools/blob/012af682a7f7482f4a7863364bb78194740a4937/packages/genshintoolsapp/lib/view/character/page_character_list.dart#L20)的未知BUG导致角色节目加载巨慢