### PR TITLE
调整数据存储位置

### DIFF
--- a/packages/genshintoolsapp/lib/main.dart
+++ b/packages/genshintoolsapp/lib/main.dart
@@ -27,7 +27,7 @@ void main() async {
 
         var d = kIsWeb
             ? HydratedStorage.webStorageDirectory
-            : await getTemporaryDirectory();
+            : await getApplicationDocumentsDirectory();
 
         return HydratedStorage.build(
           storageDirectory: d,


### PR DESCRIPTION
部分安卓手机会自动清理应用缓存，导致账号信息经常被清空。
所以将数据存储位置从"临时目录"调整到"文档目录"。